### PR TITLE
openssh and iptables: Add ssh brute force prevention with openssh

### DIFF
--- a/SPECS/openssh/openssh.spec
+++ b/SPECS/openssh/openssh.spec
@@ -142,7 +142,9 @@ iptables -t mangle -A SSHBRUTEFORCE -j DROP
 iptables -t mangle -A PREROUTING -p tcp --dport ssh -m conntrack --ctstate NEW -m recent --set
 iptables -t mangle -A PREROUTING -p tcp --dport ssh -m conntrack --ctstate NEW -m recent --update --seconds 60 --hitcount 6 -j SSHBRUTEFORCE
 EOF'
-sudo bash -c 'echo "iptables-restore < /etc/systemd/scripts/ipsave-custom" >> /etc/systemd/scripts/iptables'
+#sudo sed '/# End/d' /etc/systemd/scripts/iptables
+#sudo bash -c 'echo "iptables-restore < /etc/systemd/scripts/ipsave-custom" >> /etc/systemd/scripts/iptables'
+#sudo bash -c 'echo "# End /etc/systemd/scripts/iptables" >> /etc/systemd/scripts/iptables'
 sudo bash /etc/systemd/scripts/ipsave-custom 
 
 %postun server
@@ -162,7 +164,7 @@ sudo iptables -t mangle -D  PREROUTING -p tcp --dport ssh -m conntrack --ctstate
 sudo iptables -t mangle -D  PREROUTING -p tcp --dport ssh -m conntrack --ctstate NEW -m recent --update --seconds 60 --hitcount 6 -j SSHBRUTEFORCE
 sudo iptables -t mangle --flush SSHBRUTEFORCE
 sudo iptables -t mangle -X SSHBRUTEFORCE
-sudo sed '/ipsave-custom/d' /etc/systemd/scripts/iptables
+#sudo sed '/ipsave-custom/d' /etc/systemd/scripts/iptables
 sudo rm /etc/systemd/scripts/ipsave-custom
 
 %clean

--- a/SPECS/openssh/openssh.spec
+++ b/SPECS/openssh/openssh.spec
@@ -170,7 +170,7 @@ sudo iptables -t mangle -D  PREROUTING -p tcp --dport ssh -m conntrack --ctstate
 sudo iptables -t mangle -D  PREROUTING -p tcp --dport ssh -m conntrack --ctstate NEW -m recent --update --seconds 60 --hitcount 6 -j SSHBRUTEFORCE
 sudo iptables -t mangle --flush SSHBRUTEFORCE
 sudo iptables -t mangle -X SSHBRUTEFORCE
-#sudo sed '/ipsave-custom/d' /etc/systemd/scripts/iptables
+sudo sed '/ipsave-custom/d' /etc/systemd/scripts/iptables
 sudo rm /etc/systemd/scripts/ipsave-custom
 
 %clean


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

IMPORTANT
This method holds concerns involving updates (the rules would not persist) and modifying the main iptables script (generally not ideal).

Openssh drops ssh connection after 6 consecutive unsuccessful logins from the same session (at the time of this PR). However, it does not prevent the same ip from creating new sessions and attempting less than 6 times in each. Resulting in the possibility of a brute force attack. 

Therefore, when openssh is installed, add iptables rules to prevent this attack. The rules are added in a script ipsave-custom. 
This script does the following
1. Track ssh connections in the mangle table, prerouting chain 
2. Send to custom chain SSHBRUTEFORCE if over 6 attempts in 60seconds
3. Log the ip address
4. Drop packets from that ip address

In order for the changes to persist after reboot, the iptables script now restores ipsave-custom.

Reference: https://dailydoseoftech.com/how-to-setup-ssh-brute-force-protection-with-iptables/ 
Signed off by: Rachel Menge (rachelmenge)

###### Change Log  <!-- REQUIRED -->


###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- local build (in progress)
- To test brute force attack, ran the following with 8 incorrect passwords
```start putty mariner_user@<ip-address-of-target> -pw %1```
