### PR TITLE
Nettle: update to 3.7.2 for CVE-2021-20305

### DIFF
--- a/SPECS/chrony/chrony.spec
+++ b/SPECS/chrony/chrony.spec
@@ -4,7 +4,7 @@
 
 Name:           chrony
 Version:        3.5.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        An NTP client/server
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
@@ -30,7 +30,7 @@ BuildRequires:  gnupg2
 BuildRequires:  libcap-devel
 BuildRequires:  libedit-devel
 BuildRequires:  libseccomp-devel
-BuildRequires:  nettle-devel
+BuildRequires:  nettle-devel >= 3.7.2
 BuildRequires:  systemd
 
 %if %{with_check}
@@ -201,6 +201,9 @@ systemctl start chronyd.service
 %dir %attr(-,chrony,chrony) %{_localstatedir}/log/chrony
 
 %changelog
+* Tue Apr 13 2021 Rachel Menge <rachelmenge@microsoft.com> - 3.5.1-4
+- Bump release to rebuild with new nettle (3.7.2)
+
 * Fri Jan 15 2021 Andrew Phelps <anphel@microsoft.com> - 3.5.1-3
 - Add build requirements needed for check tests
 

--- a/SPECS/glib-networking/glib-networking.spec
+++ b/SPECS/glib-networking/glib-networking.spec
@@ -1,7 +1,7 @@
 Summary:        Glib networking modules
 Name:           glib-networking
 Version:        2.59.1
-Release:        6%{?dist}
+Release:        7%{?dist}
 License:        GPLv2+ with exceptions
 URL:            https://gitlab.gnome.org/GNOME/glib-networking/
 Group:          System Environment/Development
@@ -11,7 +11,7 @@ Source0:        http://ftp.gnome.org/pub/GNOME/sources/glib-networking/2.59/%{na
 
 Patch0:         CVE-2020-13645.patch
 
-BuildRequires:	nettle-devel
+BuildRequires:	nettle-devel >= 3.7.2
 BuildRequires:	autogen-libopts-devel
 BuildRequires:	libtasn1-devel
 BuildRequires:  gnutls-devel
@@ -23,7 +23,7 @@ BuildRequires:  glib-schemas
 BuildRequires:  meson
 BuildRequires:  gnome-common
 BuildRequires:  ninja-build
-Requires:	nettle
+Requires:	nettle >= 3.7.2
 Requires:	gnutls
 Requires:	libtasn1
 Requires:	openssl
@@ -72,6 +72,8 @@ ninja test
 %defattr(-,root,root)
 
 %changelog
+*   Tue Apr 13 2021 Rachel Menge <rachelmengem@microsoft.com> - 2.59.1-7
+-   Bump release to rebuild with new nettle (3.7.2)
 *   Tue Aug 18 2020 Henry Beberman <hebeberm@microsoft.com> - 2.59.1-6
 -   Backport patch for CVE-2020-13645
 *   Sat May 09 00:20:40 PST 2020 Nick Samson <nisamson@microsoft.com> - 2.59.1-5

--- a/SPECS/gnutls/gnutls.spec
+++ b/SPECS/gnutls/gnutls.spec
@@ -1,7 +1,7 @@
 Summary:        The GnuTLS Transport Layer Security Library
 Name:           gnutls
 Version:        3.6.14
-Release:        5%{?dist}
+Release:        6%{?dist}
 License:        GPLv3+ and LGPLv2+
 URL:            https://www.gnutls.org
 Source0:        ftp://ftp.gnutls.org/gcrypt/gnutls/v3.6/%{name}-%{version}.tar.xz
@@ -9,7 +9,7 @@ Group:          System Environment/Libraries
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
 
-BuildRequires:  nettle-devel
+BuildRequires:  nettle-devel >= 3.7.2
 BuildRequires:  autogen-libopts-devel
 BuildRequires:  libtasn1-devel
 BuildRequires:  openssl-devel
@@ -20,7 +20,7 @@ BuildRequires:  net-tools
 BuildRequires:  which
 %endif
 
-Requires:       nettle
+Requires:       nettle >= 3.7.2
 Requires:       autogen-libopts
 Requires:       libtasn1
 Requires:       openssl
@@ -102,6 +102,8 @@ make %{?_smp_mflags} check
 %{_mandir}/man3/*
 
 %changelog
+*   Tue Apr 13 2021 Rachel Menge <rachelmengem@microsoft.com> - 3.6.14-6
+-   Bump release to rebuild with new nettle (3.7.2)
 *   Mon Mar 22 2021 Mateusz Malisz <mamalisz@microsoft.com> 3.6.14-5
 -   Apply patch for CVE-2021-20231 and CVE-2021-20231 from upstream.
 *   Tue Jan 26 2021 Andrew Phelps <anphel@microsoft.com> 3.6.14-4

--- a/SPECS/nettle/nettle.signatures.json
+++ b/SPECS/nettle/nettle.signatures.json
@@ -1,5 +1,5 @@
 {
  "Signatures": {
-  "nettle-3.4.1.tar.gz": "f941cf1535cd5d1819be5ccae5babef01f6db611f9b5a777bae9c7604b8a92ad"
+  "nettle-3.7.2.tar.gz": "8d2a604ef1cde4cd5fb77e422531ea25ad064679ff0adf956e78b3352e0ef162"
  }
 }

--- a/SPECS/nettle/nettle.spec
+++ b/SPECS/nettle/nettle.spec
@@ -1,17 +1,17 @@
 Summary:	Low level cryptographic libraries
 Name:		nettle
-Version:    3.4.1
-Release:    2%{?dist}
+Version:    3.7.2
+Release:    1%{?dist}
 License:	LGPLv3+ or GPLv2+
 URL:        https://www.lysator.liu.se/~nisse/nettle/
 Source0: 	https://ftp.gnu.org/gnu/nettle/%{name}-%{version}.tar.gz
 Group: 		Development/Libraries
 Vendor:         Microsoft Corporation
 Distribution:   Mariner
-Provides:	libhogweed.so.4()(64bit)
-Provides:	libhogweed.so.4(HOGWEED_4)(64bit)
-Provides:	libnettle.so.6()(64bit)
-Provides:	libnettle.so.6(NETTLE_6)(64bit)
+Provides:	libhogweed.so.6()(64bit)
+Provides:	libhogweed.so.6(HOGWEED_6)(64bit)
+Provides:	libnettle.so.8()(64bit)
+Provides:	libnettle.so.8(NETTLE_8)(64bit)
 Requires:	gmp
 
 %description
@@ -63,24 +63,25 @@ make %{?_smp_mflags} check
 %{_libdir}/pkgconfig/*.pc
 
 %changelog
+* Mon Apr 12 2021 Rachel Menge <rachelmenge@microsoft.com> - 3.7.2-1
+- Update to 3.7.2 for CVE-2021-20305
 * Sat May 09 00:20:58 PST 2020 Nick Samson <nisamson@microsoft.com> - 3.4.1-2
 - Added %%license line automatically
-
-*   Mon Mar 16 2020 Henry Beberman <henry.beberman@microsoft.com> 3.4.1-1
--   Update to 3.4.1. Licence verified.
-*   Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 3.4-2
--   Initial CBL-Mariner import from Photon (license: Apache2).
-*   Thu Sep 06 2018 Anish Swaminathan <anishs@vmware.com> 3.4-1
--   Update version to 3.4
-*   Sat Apr 15 2017 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 3.3-1
--   Update to 3.3
-*   Mon Oct 04 2016 ChangLee <changLee@vmware.com> 3.2-3
--   Modified %check
-*   Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 3.2-2
--   GA - Bump release of all rpms
-*   Mon Feb 22 2016 XIaolin Li <xiaolinl@vmware.com> 3.2-1
--   Updated to version 3.2
-*   Mon Oct 12 2015 Xiaolin Li <xiaolinl@vmware.com> 3.1.1-2
--   Moving static lib files to devel package.
-*   Thu Jun 18 2015 Divya Thaluru <dthaluru@vmware.com> 3.1.1-1
--   Initial build. First version
+* Mon Mar 16 2020 Henry Beberman <henry.beberman@microsoft.com> 3.4.1-1
+- Update to 3.4.1. Licence verified.
+* Tue Sep 03 2019 Mateusz Malisz <mamalisz@microsoft.com> 3.4-2
+- Initial CBL-Mariner import from Photon (license: Apache2).
+* Thu Sep 06 2018 Anish Swaminathan <anishs@vmware.com> 3.4-1
+- Update version to 3.4
+* Sat Apr 15 2017 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 3.3-1
+- Update to 3.3
+* Mon Oct 04 2016 ChangLee <changLee@vmware.com> 3.2-3
+- Modified %check
+* Tue May 24 2016 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 3.2-2
+- GA - Bump release of all rpms
+* Mon Feb 22 2016 XIaolin Li <xiaolinl@vmware.com> 3.2-1
+- Updated to version 3.2
+* Mon Oct 12 2015 Xiaolin Li <xiaolinl@vmware.com> 3.1.1-2
+- Moving static lib files to devel package.
+* Thu Jun 18 2015 Divya Thaluru <dthaluru@vmware.com> 3.1.1-1
+- Initial build. First version

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -3615,8 +3615,8 @@
         "type": "other",
         "other": {
           "name": "nettle",
-          "version": "3.4.1",
-          "downloadUrl": "https://ftp.gnu.org/gnu/nettle/nettle-3.4.1.tar.gz"
+          "version": "3.7.2",
+          "downloadUrl": "https://ftp.gnu.org/gnu/nettle/nettle-3.7.2.tar.gz"
         }
       }
     },


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [x] The toolchain has been rebuilt successfully (or no changes were made to it)
- [x] The toolchain/worker package manifests are up-to-date
- [x] Any updated packages successfully build (or no packages were changed)
- [x] All package sources are available
- [x] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`)
- [x] All source files have up-to-date hashes in the `*.signatures.json` files
- [x] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [x] Documentation has been updated to match any changes to the build system
- [x] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Nettle was updated to 3.7.2 in order to fix CVE-2021-20305. However, in nettle 3.6, the .so's `libhogweed` and `libnettle` were renamed. Therefore, nettle's provides needed to be updated to reflect this change. 

This also required a release bump to the specs `chrony`, `glib-networking`, and `gnutils`, which contain `nettle` as a build requires.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Update nettle to 3.7.2 to fix CVE-2021-20305
- Bump release of `chrony`, `glib-networking`, and `gnutils`

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
NO

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-2021-20305

###### Test Methodology
<!-- How as this test validated? i.e. local build, pipeline build etc. -->
- local build (x86, vhdx)