### PR TITLE
Add srpmdownloader

### DIFF
--- a/toolkit/scripts/srpm_pack.mk
+++ b/toolkit/scripts/srpm_pack.mk
@@ -67,25 +67,14 @@ $(STATUS_FLAGS_DIR)/build_srpms.flag: $(chroot_worker) $(local_specs) $(local_sp
 			--tls-cert=$(TLS_CERT) \
 			--tls-key=$(TLS_KEY) \
 			--spec-input=$${spec_file} \
+			--srpm-urls=$(SRPM_URL_LIST) \
 			--build-dir=$(SRPM_BUILD_CHROOT_DIR) \
 			--signature-handling=$(SRPM_FILE_SIGNATURE_HANDLING) \
 			--worker-tar=$(chroot_worker)  \
 		$(if $(filter y,$(RUN_CHECK)),--run-check) \
 		--log-file=$(SRPM_BUILD_LOGS_DIR)/srpmdownloader.log \
 		--log-level=$(LOG_LEVEL) )  && \
-		echo $${srpm_file} && \
-		for url in $(SRPM_URL_LIST); do \
-			wget $${url}/$${srpm_file} \
-				-O $(BUILD_SRPMS_DIR)/$${srpm_file} \
-				--no-verbose \
-				$(if $(TLS_CERT),--certificate=$(TLS_CERT)) \
-				$(if $(TLS_KEY),--private-key=$(TLS_KEY)) \
-				&& \
-			touch $(BUILD_SRPMS_DIR)/$${srpm_file} && \
-			break; \
-		done || $(call print_error,Loop in $@ failed) ; \
-		{ [ -f $(BUILD_SRPMS_DIR)/$${srpm_file} ] || \
-			$(call print_error,Failed to download $${srpm_file});  } \
+		echo $${srpm_file} ; \
 	done || $(call print_error,Loop in $@ failed) ; \
 	touch $@
 

--- a/toolkit/scripts/srpm_pack.mk
+++ b/toolkit/scripts/srpm_pack.mk
@@ -61,15 +61,10 @@ $(STATUS_FLAGS_DIR)/build_srpms.flag: $(chroot_worker) $(local_specs) $(local_sp
 		srpm_file=$$($(go-srpmdownloader) \
 			--dir=$(SPECS_DIR) \
 			--output-dir=$(BUILD_SRPMS_DIR) \
-			--source-url=$(SOURCE_URL) \
 			--dist-tag=$(DIST_TAG) \
-			--ca-cert=$(CA_CERT) \
-			--tls-cert=$(TLS_CERT) \
-			--tls-key=$(TLS_KEY) \
 			--spec-input=$${spec_file} \
 			--srpm-urls=$(SRPM_URL_LIST) \
 			--build-dir=$(SRPM_BUILD_CHROOT_DIR) \
-			--signature-handling=$(SRPM_FILE_SIGNATURE_HANDLING) \
 			--worker-tar=$(chroot_worker)  \
 		$(if $(filter y,$(RUN_CHECK)),--run-check) \
 		--log-file=$(SRPM_BUILD_LOGS_DIR)/srpmdownloader.log \

--- a/toolkit/scripts/srpm_pack.mk
+++ b/toolkit/scripts/srpm_pack.mk
@@ -55,10 +55,25 @@ $(BUILD_SRPMS_DIR): $(STATUS_FLAGS_DIR)/build_srpms.flag
 	@echo Finished updating $@
 
 ifeq ($(DOWNLOAD_SRPMS),y)
-$(STATUS_FLAGS_DIR)/build_srpms.flag: $(local_specs) $(local_spec_dirs) $(SPECS_DIR)
+$(STATUS_FLAGS_DIR)/build_srpms.flag: $(chroot_worker) $(local_specs) $(local_spec_dirs) $(SPECS_DIR) $(go-srpmdownloader)
 	for spec in $(local_specs); do \
 		spec_file=$${spec} && \
-		srpm_file=$$(rpmspec -q $${spec_file} --srpm --define='with_check 1' --define='dist $(DIST_TAG)' --queryformat %{NAME}-%{VERSION}-%{RELEASE}.src.rpm) && \
+		srpm_file=$$($(go-srpmdownloader)) \
+			--dir=$(SPECS_DIR) \
+			--output-dir=$(BUILD_SRPMS_DIR) \
+			--source-url=$(SOURCE_URL) \
+			--dist-tag=$(DIST_TAG) \
+			--ca-cert=$(CA_CERT) \
+			--tls-cert=$(TLS_CERT) \
+			--tls-key=$(TLS_KEY) \
+			--build-dir=$(SRPM_BUILD_CHROOT_DIR) \
+			--signature-handling=$(SRPM_FILE_SIGNATURE_HANDLING) \
+			--worker-tar=$(chroot_worker) \
+		$(if $(filter y,$(RUN_CHECK)),--run-check) \
+		$(if $(SRPM_PACK_LIST),--pack-list=$(srpm_pack_list_file)) \
+		--log-file=$(SRPM_BUILD_LOGS_DIR)/srpmpacker.log \
+		--log-level=$(LOG_LEVEL) && \
+		# srpm_file=$$(rpmspec -q $${spec_file} --srpm --define='with_check 1' --define='dist $(DIST_TAG)' --queryformat %{NAME}-%{VERSION}-%{RELEASE}.src.rpm) && \
 		for url in $(SRPM_URL_LIST); do \
 			wget $${url}/$${srpm_file} \
 				-O $(BUILD_SRPMS_DIR)/$${srpm_file} \

--- a/toolkit/scripts/srpm_pack.mk
+++ b/toolkit/scripts/srpm_pack.mk
@@ -58,7 +58,7 @@ ifeq ($(DOWNLOAD_SRPMS),y)
 $(STATUS_FLAGS_DIR)/build_srpms.flag: $(chroot_worker) $(local_specs) $(local_spec_dirs) $(SPECS_DIR) $(go-srpmdownloader)
 	for spec in $(local_specs); do \
 		spec_file=$${spec} && \
-		srpm_file=$$($(go-srpmdownloader)) \
+		srpm_file=$$($(go-srpmdownloader) \
 			--dir=$(SPECS_DIR) \
 			--output-dir=$(BUILD_SRPMS_DIR) \
 			--source-url=$(SOURCE_URL) \
@@ -66,14 +66,14 @@ $(STATUS_FLAGS_DIR)/build_srpms.flag: $(chroot_worker) $(local_specs) $(local_sp
 			--ca-cert=$(CA_CERT) \
 			--tls-cert=$(TLS_CERT) \
 			--tls-key=$(TLS_KEY) \
+			--spec-input=$${spec_file} \
 			--build-dir=$(SRPM_BUILD_CHROOT_DIR) \
 			--signature-handling=$(SRPM_FILE_SIGNATURE_HANDLING) \
-			--worker-tar=$(chroot_worker) \
+			--worker-tar=$(chroot_worker)  \
 		$(if $(filter y,$(RUN_CHECK)),--run-check) \
-		$(if $(SRPM_PACK_LIST),--pack-list=$(srpm_pack_list_file)) \
-		--log-file=$(SRPM_BUILD_LOGS_DIR)/srpmpacker.log \
-		--log-level=$(LOG_LEVEL) && \
-		# srpm_file=$$(rpmspec -q $${spec_file} --srpm --define='with_check 1' --define='dist $(DIST_TAG)' --queryformat %{NAME}-%{VERSION}-%{RELEASE}.src.rpm) && \
+		--log-file=$(SRPM_BUILD_LOGS_DIR)/srpmdownloader.log \
+		--log-level=$(LOG_LEVEL) )  && \
+		echo $${srpm_file} && \
 		for url in $(SRPM_URL_LIST); do \
 			wget $${url}/$${srpm_file} \
 				-O $(BUILD_SRPMS_DIR)/$${srpm_file} \

--- a/toolkit/scripts/srpm_pack.mk
+++ b/toolkit/scripts/srpm_pack.mk
@@ -55,22 +55,18 @@ $(BUILD_SRPMS_DIR): $(STATUS_FLAGS_DIR)/build_srpms.flag
 	@echo Finished updating $@
 
 ifeq ($(DOWNLOAD_SRPMS),y)
-$(STATUS_FLAGS_DIR)/build_srpms.flag: $(chroot_worker) $(local_specs) $(local_spec_dirs) $(SPECS_DIR) $(go-srpmdownloader)
-	for spec in $(local_specs); do \
-		spec_file=$${spec} && \
-		srpm_file=$$($(go-srpmdownloader) \
-			--dir=$(SPECS_DIR) \
-			--output-dir=$(BUILD_SRPMS_DIR) \
-			--dist-tag=$(DIST_TAG) \
-			--spec-input=$${spec_file} \
-			--srpm-source-urls=$(SRPM_URL_LIST) \
-			--build-dir=$(SRPM_BUILD_CHROOT_DIR) \
-			--worker-tar=$(chroot_worker)  \
+$(STATUS_FLAGS_DIR)/build_srpms.flag: $(chroot_worker) $(local_specs) $(local_spec_dirs) $(SPECS_DIR) $(go-srpmdownloader) $(srpm_pack_list_file)
+	srpm_file=$$($(go-srpmdownloader) \
+		--dir=$(SPECS_DIR) \
+		--output-dir=$(BUILD_SRPMS_DIR) \
+		--dist-tag=$(DIST_TAG) \
+		--srpm-source-urls=$(SRPM_URL_LIST) \
+		--build-dir=$(SRPM_BUILD_CHROOT_DIR) \
+		--worker-tar=$(chroot_worker)  \
+		--srpm-list=$(srpm_pack_list_file) \
 		$(if $(filter y,$(RUN_CHECK)),--run-check) \
 		--log-file=$(SRPM_BUILD_LOGS_DIR)/srpmdownloader.log \
 		--log-level=$(LOG_LEVEL) )  && \
-		echo $${srpm_file} ; \
-	done || $(call print_error,Loop in $@ failed) ; \
 	touch $@
 
 # Since all the SRPMs are being downloaded by the "input-srpms" target there is no need to differentiate toolchain srpms.

--- a/toolkit/scripts/srpm_pack.mk
+++ b/toolkit/scripts/srpm_pack.mk
@@ -63,7 +63,7 @@ $(STATUS_FLAGS_DIR)/build_srpms.flag: $(chroot_worker) $(local_specs) $(local_sp
 			--output-dir=$(BUILD_SRPMS_DIR) \
 			--dist-tag=$(DIST_TAG) \
 			--spec-input=$${spec_file} \
-			--srpm-urls=$(SRPM_URL_LIST) \
+			--srpm-source-urls=$(SRPM_URL_LIST) \
 			--build-dir=$(SRPM_BUILD_CHROOT_DIR) \
 			--worker-tar=$(chroot_worker)  \
 		$(if $(filter y,$(RUN_CHECK)),--run-check) \

--- a/toolkit/scripts/tools.mk
+++ b/toolkit/scripts/tools.mk
@@ -29,6 +29,7 @@ go_tool_list = \
 	roast \
 	scheduler \
 	specreader \
+	srpmdownloader \
 	srpmpacker \
 	validatechroot \
 

--- a/toolkit/tools/srpmdownloader/srpmdownloader.go
+++ b/toolkit/tools/srpmdownloader/srpmdownloader.go
@@ -6,7 +6,6 @@ package main
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -18,6 +17,7 @@ import (
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/rpm"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/safechroot"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/shell"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )
@@ -92,13 +92,11 @@ var (
 	logFile  = exe.LogFileFlag(app)
 	logLevel = exe.LogLevelFlag(app)
 
-	buildDir     = app.Flag("build-dir", "Directory to store temporary files while building.").Default(defaultBuildDir).String()
-	distTag      = app.Flag("dist-tag", "The distribution tag SRPMs will be built with.").Required().String()
-	packListFile = app.Flag("pack-list", "Path to a list of SPECs to pack. If empty will pack all SPECs.").ExistingFile()
-	runCheck     = app.Flag("run-check", "Whether or not to run the spec file's check section during package build.").Bool()
+	buildDir = app.Flag("build-dir", "Directory to store temporary files while building.").Default(defaultBuildDir).String()
+	distTag  = app.Flag("dist-tag", "The distribution tag SRPMs will be built with.").Required().String()
+	runCheck = app.Flag("run-check", "Whether or not to run the spec file's check section during package build.").Bool()
 
 	workers          = app.Flag("workers", "Number of concurrent goroutines to parse with.").Default(defaultWorkerCount).Int()
-	repackAll        = app.Flag("repack", "Rebuild all SRPMs, even if already built.").Bool()
 	nestedSourcesDir = app.Flag("nested-sources", "Set if for a given SPEC, its sources are contained in a SOURCES directory next to the SPEC file.").Bool()
 
 	// Use String() and not ExistingFile() as the Makefile may pass an empty string if the user did not specify any of these options
@@ -107,6 +105,7 @@ var (
 	tlsClientCert = app.Flag("tls-cert", "TLS client certificate to use when downloading files.").String()
 	tlsClientKey  = app.Flag("tls-key", "TLS client key to use when downloading files.").String()
 	specInput     = app.Flag("spec-input", "Spec that needs SRPM.").String()
+	srpmURLs      = app.Flag("srpm-urls", "urls for SRPM.").String()
 
 	workerTar = app.Flag("worker-tar", "Full path to worker_chroot.tar.gz. If this argument is empty, SRPMs will be packed in the host environment.").ExistingFile()
 
@@ -143,7 +142,7 @@ func main() {
 
 	// Setup remote source configuration
 	var err error
-	var packageURL []string
+	var packageName []string
 	templateSrcConfig.sourceURL = *sourceURL
 	templateSrcConfig.caCerts, err = x509.SystemCertPool()
 	logger.PanicOnError(err, "Received error calling x509.SystemCertPool(). Error: %v", err)
@@ -165,13 +164,38 @@ func main() {
 		templateSrcConfig.tlsCerts = append(templateSrcConfig.tlsCerts, cert)
 	}
 
-	logger.PanicOnError(err)
-	packageURL, err = getURLSRPMsWrapper(*specsDir, *distTag, *buildDir, *outDir, *workerTar, *workers, *nestedSourcesDir, *runCheck, *specInput, templateSrcConfig)
-	logger.PanicOnError(err)
-	first := packageURL[0]
+	//spec := "/home/rachel/repos/CBL-Mariner-test/SPECS/iptables/iptables.spec"
 
-	fmt.Println(first)
+	packageName, err = getURLSRPMsWrapper(*specsDir, *distTag, *buildDir, *outDir, *workerTar, *workers, *nestedSourcesDir, *runCheck, *specInput, templateSrcConfig)
+	logger.PanicOnError(err)
+	srpmfilename := packageName[0]
 
+	// Assumes that srpmURLs come in as ',' seperated
+	urls := strings.Split(*srpmURLs, ",")
+	// for _, n := range urls {
+	// 	logger.Log.Infof("%s", n)
+	// }
+	for _, url := range urls {
+		fullurlwithsrpm := url + "/" + srpmfilename
+
+		wgetArgs := []string{
+			fullurlwithsrpm,
+		}
+		_, stderr, err := shell.Execute("wget", wgetArgs...)
+		if err != nil {
+			logger.Log.Warn(stderr)
+		} else {
+			mvArgs := []string{
+				srpmfilename,
+				*outDir,
+			}
+			_, stderr, err := shell.Execute("mv", mvArgs...)
+			if err != nil {
+				logger.Log.Warn(stderr)
+			}
+			break
+		}
+	}
 }
 
 // createAllSRPMsWrapper wraps createAllSRPMs to conditionally run it inside a chroot.

--- a/toolkit/tools/srpmdownloader/srpmdownloader.go
+++ b/toolkit/tools/srpmdownloader/srpmdownloader.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/buildpipeline"
 	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/directory"
@@ -105,6 +106,7 @@ var (
 	caCertFile    = app.Flag("ca-cert", "Root certificate authority to use when downloading files.").String()
 	tlsClientCert = app.Flag("tls-cert", "TLS client certificate to use when downloading files.").String()
 	tlsClientKey  = app.Flag("tls-key", "TLS client key to use when downloading files.").String()
+	specInput     = app.Flag("spec-input", "Spec that needs SRPM.").String()
 
 	workerTar = app.Flag("worker-tar", "Full path to worker_chroot.tar.gz. If this argument is empty, SRPMs will be packed in the host environment.").ExistingFile()
 
@@ -116,6 +118,8 @@ func main() {
 	app.Version(exe.ToolkitVersion)
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	logger.InitBestEffort(*logFile, *logLevel)
+	logger.Log.Infof("Begin SRPM downloader")
+	logger.Log.Infof("SRPM for %s", *specInput)
 
 	if *workers <= 0 {
 		logger.Log.Fatalf("Value in --workers must be greater than zero. Found %d", *workers)
@@ -161,16 +165,12 @@ func main() {
 		templateSrcConfig.tlsCerts = append(templateSrcConfig.tlsCerts, cert)
 	}
 
-	// A spec list may be provided, if so only download this subset.
-
-	var packList = "kernel"
-
 	logger.PanicOnError(err)
-
-	packageURL, err = getURLSRPMsWrapper(*specsDir, *distTag, *buildDir, *outDir, *workerTar, *workers, *nestedSourcesDir, *runCheck, packList, templateSrcConfig)
+	packageURL, err = getURLSRPMsWrapper(*specsDir, *distTag, *buildDir, *outDir, *workerTar, *workers, *nestedSourcesDir, *runCheck, *specInput, templateSrcConfig)
 	logger.PanicOnError(err)
+	first := packageURL[0]
 
-	fmt.Println(packageURL)
+	fmt.Println(first)
 
 }
 
@@ -195,10 +195,10 @@ func getURLSRPMsWrapper(specsDir, distTag, buildDir, outDir, workerTar string, w
 	}
 
 	if chroot != nil {
-		logger.Log.Info("Packing SRPMs inside a chroot environment")
+		logger.Log.Info("Grabbing SRPMs URL inside a chroot environment")
 		err = chroot.Run(doCreateAll)
 	} else {
-		logger.Log.Info("Packing SRPMs in the host environment")
+		logger.Log.Info("Grabbing SRPMs URL SRPMs in the host environment")
 		err = doCreateAll()
 	}
 
@@ -225,11 +225,22 @@ func getURLSRPMs(specsDir, distTag, buildDir, outDir string, workers int, nested
 		querySrpm             = `%{NAME}-%{VERSION}-%{RELEASE}.src.rpm`
 		queryProvidedPackages = `rpm %{ARCH}/%{nvra}.rpm\n[provides %{PROVIDENEVRS}\n][requires %{REQUIRENEVRS}\n][arch %{ARCH}\n]`
 	)
+	// Find the SRPM that this SPEC will produce.
+	defines := rpm.DefaultDefines(runCheck)
+	defines[rpm.DistTagDefine] = distTag
+
 	logger.Log.Infof("Finding SPEC's SRPM URL")
 	sourcedir := filepath.Dir(specfile)
-	defines := rpm.DefaultDefines(runCheck)
+
+	pathstr := strings.Split(specfile, "/")
+	spec := pathstr[len(pathstr)-1]
+	//spec = "cri-o.spec"
+	specsplice := strings.Split(spec, ".")
+	spec2 := specsplice[0]
+
+	spec = "/specs/" + spec2 + "/" + spec
 	// Find the SRPM associated with the SPEC.
-	return rpm.QuerySPEC(specfile, sourcedir, querySrpm, defines, rpm.QueryHeaderArgument)
+	return rpm.QuerySPEC(spec, sourcedir, querySrpm, defines, rpm.QueryHeaderArgument)
 
 	// rpmspec -q $${spec_file} --srpm --define='with_check 1' --define='dist $(DIST_TAG)' --queryformat %{NAME}-%{VERSION}-%{RELEASE}.src.rpm
 }

--- a/toolkit/tools/srpmdownloader/srpmdownloader.go
+++ b/toolkit/tools/srpmdownloader/srpmdownloader.go
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 //TO DO
-// ADD TLS certs for Source servers that need them
-// Bug in SRPM source where setting the URL to use 1.0 still curls a .cm2 srpm (fails when same cmd runs outside of toolkit)
+// ADD TLS certs for srpm servers that need them
+// Bug in SRPM_URL_LIST where setting the URL to use 1.0 still curls a .cm2 srpm (fails when same cmd runs outside of toolkit)
 // Bug where the SRPM_PACK_LIST= will not clear srpm_pack_list_file ($(BUILD_SRPMS_DIR)/pack_list.txt) even if argument is empty
 // A lot of code duplication w/ srpmpacker. Should make a library
 

--- a/toolkit/tools/srpmdownloader/srpmdownloader.go
+++ b/toolkit/tools/srpmdownloader/srpmdownloader.go
@@ -1,6 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+//TO DO
+// do I need certs? I think no
+// fix srpm url lists handling. How do I test?
+// why do I need to mv instead of specifiying the output dir for wget?
+// keep wget in main?
+
 package main
 
 import (
@@ -40,8 +46,8 @@ var (
 	nestedSourcesDir = app.Flag("nested-sources", "Set if for a given SPEC, its sources are contained in a SOURCES directory next to the SPEC file.").Bool()
 
 	// Use String() and not ExistingFile() as the Makefile may pass an empty string if the user did not specify any of these options
-	specInput = app.Flag("spec-input", "Spec that needs SRPM.").String()
-	srpmURLs  = app.Flag("srpm-urls", "urls for SRPM.").String()
+	specInput      = app.Flag("spec-input", "Spec that needs SRPM.").String()
+	srpmSourceURLs = app.Flag("srpm-source-urls", "urls for SRPM.").String()
 
 	workerTar = app.Flag("worker-tar", "Full path to worker_chroot.tar.gz. If this argument is empty, SRPMs will be packed in the host environment.").ExistingFile()
 )
@@ -50,8 +56,7 @@ func main() {
 	app.Version(exe.ToolkitVersion)
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	logger.InitBestEffort(*logFile, *logLevel)
-	logger.Log.Infof("Begin SRPM downloader")
-	logger.Log.Infof("SRPM for %s", *specInput)
+	logger.Log.Infof("Downloading SRPM for %s", *specInput)
 
 	if *workers <= 0 {
 		logger.Log.Fatalf("Value in --workers must be greater than zero. Found %d", *workers)
@@ -59,31 +64,31 @@ func main() {
 
 	// Setup remote source configuration
 	var err error
-	var packageName []string
+	var packageSRPM string
 
 	//spec := "/home/rachel/repos/CBL-Mariner-test/SPECS/iptables/iptables.spec"
 
-	packageName, err = getURLSRPMsWrapper(*specsDir, *distTag, *buildDir, *outDir, *workerTar, *workers, *nestedSourcesDir, *runCheck, *specInput)
+	packageSRPM, err = getSRPMQueryWrapper(*specsDir, *distTag, *buildDir, *outDir, *workerTar, *workers, *nestedSourcesDir, *runCheck, *specInput)
 	logger.PanicOnError(err)
-	srpmfilename := packageName[0]
 
-	// Assumes that srpmURLs come in as ',' seperated
-	urls := strings.Split(*srpmURLs, ",")
+	// Assumes that srpmSourceURLs come in as ',' seperated
+	urls := strings.Split(*srpmSourceURLs, ",")
 	// for _, n := range urls {
 	// 	logger.Log.Infof("%s", n)
 	// }
+
 	for _, url := range urls {
-		fullurlwithsrpm := url + "/" + srpmfilename
+		srpmURL := url + "/" + packageSRPM
 
 		wgetArgs := []string{
-			fullurlwithsrpm,
+			srpmURL,
 		}
 		_, stderr, err := shell.Execute("wget", wgetArgs...)
 		if err != nil {
 			logger.Log.Warn(stderr)
 		} else {
 			mvArgs := []string{
-				srpmfilename,
+				packageSRPM,
 				*outDir,
 			}
 			_, stderr, err := shell.Execute("mv", mvArgs...)
@@ -95,12 +100,12 @@ func main() {
 	}
 }
 
-// createAllSRPMsWrapper wraps createAllSRPMs to conditionally run it inside a chroot.
+// getSRPMQueryWrapper wraps getSRPMQuery to conditionally run it inside a chroot.
 // If workerTar is non-empty, packing will occur inside a chroot, otherwise it will run on the host system.
-func getURLSRPMsWrapper(specsDir, distTag, buildDir, outDir, workerTar string, workers int, nestedSourcesDir, runCheck bool, packList string) (result []string, err error) {
+func getSRPMQueryWrapper(specsDir, distTag, buildDir, outDir, workerTar string, workers int, nestedSourcesDir, runCheck bool, packList string) (result string, err error) {
 	var chroot *safechroot.Chroot
 	originalOutDir := outDir
-	var packageURL []string
+	var querySRPMResult []string
 	if workerTar != "" {
 		const leaveFilesOnDisk = false
 		chroot, buildDir, outDir, specsDir, err = createChroot(workerTar, buildDir, outDir, specsDir)
@@ -111,7 +116,7 @@ func getURLSRPMsWrapper(specsDir, distTag, buildDir, outDir, workerTar string, w
 	}
 
 	doCreateAll := func() error {
-		packageURL, err = getURLSRPMs(specsDir, distTag, buildDir, outDir, workers, nestedSourcesDir, runCheck, packList)
+		querySRPMResult, err = getSRPMQuery(specsDir, distTag, buildDir, outDir, workers, nestedSourcesDir, runCheck, packList)
 		return err
 	}
 
@@ -134,23 +139,21 @@ func getURLSRPMsWrapper(specsDir, distTag, buildDir, outDir, workerTar string, w
 		err = directory.CopyContents(srpmsInChroot, originalOutDir)
 	}
 
-	result = packageURL
+	result = querySRPMResult[0]
 
 	return
 }
 
-// createAllSRPMs will find all SPEC files in specsDir and pack SRPMs for them if needed.
-func getURLSRPMs(specsDir, distTag, buildDir, outDir string, workers int, nestedSourcesDir, runCheck bool, specfile string) (result []string, err error) {
+// getSRPMQuery queries for the name, version and release of the SRPM
+func getSRPMQuery(specsDir, distTag, buildDir, outDir string, workers int, nestedSourcesDir, runCheck bool, specfile string) (result []string, err error) {
 	const (
-		emptyQueryFormat      = ``
-		querySrpm             = `%{NAME}-%{VERSION}-%{RELEASE}.src.rpm`
-		queryProvidedPackages = `rpm %{ARCH}/%{nvra}.rpm\n[provides %{PROVIDENEVRS}\n][requires %{REQUIRENEVRS}\n][arch %{ARCH}\n]`
+		emptyQueryFormat = ``
+		querySrpm        = `%{NAME}-%{VERSION}-%{RELEASE}.src.rpm`
 	)
 	// Find the SRPM that this SPEC will produce.
 	defines := rpm.DefaultDefines(runCheck)
 	defines[rpm.DistTagDefine] = distTag
 
-	logger.Log.Infof("Finding SPEC's SRPM URL")
 	sourcedir := filepath.Dir(specfile)
 
 	pathstr := strings.Split(specfile, "/")

--- a/toolkit/tools/srpmdownloader/srpmdownloader.go
+++ b/toolkit/tools/srpmdownloader/srpmdownloader.go
@@ -1,0 +1,303 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/buildpipeline"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/directory"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/exe"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/logger"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/rpm"
+	"github.com/microsoft/CBL-Mariner/toolkit/tools/internal/safechroot"
+
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+type fileSignaturesWrapper struct {
+	FileSignatures map[string]string `json:"Signatures"`
+}
+
+const (
+	srpmOutDir     = "SRPMS"
+	srpmSPECDir    = "SPECS"
+	srpmSOURCESDir = "SOURCES"
+)
+
+type fileType int
+
+const (
+	fileTypePatch  fileType = iota
+	fileTypeSource fileType = iota
+)
+
+type signatureHandlingType int
+
+const (
+	signatureEnforce   signatureHandlingType = iota
+	signatureSkipCheck signatureHandlingType = iota
+	signatureUpdate    signatureHandlingType = iota
+)
+
+const (
+	signatureEnforceString   = "enforce"
+	signatureSkipCheckString = "skip"
+	signatureUpdateString    = "update"
+)
+
+const (
+	defaultBuildDir    = "./build/SRPMS"
+	defaultWorkerCount = "10"
+)
+
+// sourceRetrievalConfiguration holds information on where to hydrate files from.
+type sourceRetrievalConfiguration struct {
+	localSourceDir string
+	sourceURL      string
+	caCerts        *x509.CertPool
+	tlsCerts       []tls.Certificate
+
+	signatureHandling signatureHandlingType
+	signatureLookup   map[string]string
+}
+
+// packResult holds the worker results from packing a SPEC file into an SRPM.
+type packResult struct {
+	specFile string
+	srpmFile string
+	err      error
+}
+
+// specState holds the state of a SPEC file: if it should be packed and the resulting SRPM if it is.
+type specState struct {
+	specFile string
+	srpmFile string
+	toPack   bool
+	err      error
+}
+
+var (
+	app = kingpin.New("srpmpacker", "A tool to package a SRPM.")
+
+	specsDir = exe.InputDirFlag(app, "Path to the SPEC directory to create SRPMs from.")
+	outDir   = exe.OutputDirFlag(app, "Directory to place the output SRPM.")
+	logFile  = exe.LogFileFlag(app)
+	logLevel = exe.LogLevelFlag(app)
+
+	buildDir     = app.Flag("build-dir", "Directory to store temporary files while building.").Default(defaultBuildDir).String()
+	distTag      = app.Flag("dist-tag", "The distribution tag SRPMs will be built with.").Required().String()
+	packListFile = app.Flag("pack-list", "Path to a list of SPECs to pack. If empty will pack all SPECs.").ExistingFile()
+	runCheck     = app.Flag("run-check", "Whether or not to run the spec file's check section during package build.").Bool()
+
+	workers          = app.Flag("workers", "Number of concurrent goroutines to parse with.").Default(defaultWorkerCount).Int()
+	repackAll        = app.Flag("repack", "Rebuild all SRPMs, even if already built.").Bool()
+	nestedSourcesDir = app.Flag("nested-sources", "Set if for a given SPEC, its sources are contained in a SOURCES directory next to the SPEC file.").Bool()
+
+	// Use String() and not ExistingFile() as the Makefile may pass an empty string if the user did not specify any of these options
+	sourceURL     = app.Flag("source-url", "URL to a source server to download SPEC sources from.").String()
+	caCertFile    = app.Flag("ca-cert", "Root certificate authority to use when downloading files.").String()
+	tlsClientCert = app.Flag("tls-cert", "TLS client certificate to use when downloading files.").String()
+	tlsClientKey  = app.Flag("tls-key", "TLS client key to use when downloading files.").String()
+
+	workerTar = app.Flag("worker-tar", "Full path to worker_chroot.tar.gz. If this argument is empty, SRPMs will be packed in the host environment.").ExistingFile()
+
+	validSignatureLevels = []string{signatureEnforceString, signatureSkipCheckString, signatureUpdateString}
+	signatureHandling    = app.Flag("signature-handling", "Specifies how to handle signature mismatches for source files.").Default(signatureEnforceString).PlaceHolder(exe.PlaceHolderize(validSignatureLevels)).Enum(validSignatureLevels...)
+)
+
+func main() {
+	app.Version(exe.ToolkitVersion)
+	kingpin.MustParse(app.Parse(os.Args[1:]))
+	logger.InitBestEffort(*logFile, *logLevel)
+
+	if *workers <= 0 {
+		logger.Log.Fatalf("Value in --workers must be greater than zero. Found %d", *workers)
+	}
+
+	// Create a template configuration that all packed SRPM will be based on.
+	var templateSrcConfig sourceRetrievalConfiguration
+
+	switch *signatureHandling {
+	case signatureEnforceString:
+		templateSrcConfig.signatureHandling = signatureEnforce
+	case signatureSkipCheckString:
+		logger.Log.Warn("Skipping signature enforcement")
+		templateSrcConfig.signatureHandling = signatureSkipCheck
+	case signatureUpdateString:
+		logger.Log.Warn("Will update signature files as needed")
+		templateSrcConfig.signatureHandling = signatureUpdate
+	default:
+		logger.Log.Fatalf("Invalid signature handling encountered: %s. Allowed: %s", *signatureHandling, validSignatureLevels)
+	}
+
+	// Setup remote source configuration
+	var err error
+	var packageURL []string
+	templateSrcConfig.sourceURL = *sourceURL
+	templateSrcConfig.caCerts, err = x509.SystemCertPool()
+	logger.PanicOnError(err, "Received error calling x509.SystemCertPool(). Error: %v", err)
+	if *caCertFile != "" {
+		newCACert, err := ioutil.ReadFile(*caCertFile)
+		if err != nil {
+			logger.Log.Panicf("Invalid CA certificate (%s), error: %s", *caCertFile, err)
+		}
+
+		templateSrcConfig.caCerts.AppendCertsFromPEM(newCACert)
+	}
+
+	if *tlsClientCert != "" && *tlsClientKey != "" {
+		cert, err := tls.LoadX509KeyPair(*tlsClientCert, *tlsClientKey)
+		if err != nil {
+			logger.Log.Panicf("Invalid TLS client key pair (%s) (%s), error: %s", *tlsClientCert, *tlsClientKey, err)
+		}
+
+		templateSrcConfig.tlsCerts = append(templateSrcConfig.tlsCerts, cert)
+	}
+
+	// A spec list may be provided, if so only download this subset.
+
+	var packList = "kernel"
+
+	logger.PanicOnError(err)
+
+	packageURL, err = getURLSRPMsWrapper(*specsDir, *distTag, *buildDir, *outDir, *workerTar, *workers, *nestedSourcesDir, *runCheck, packList, templateSrcConfig)
+	logger.PanicOnError(err)
+
+	fmt.Println(packageURL)
+
+}
+
+// createAllSRPMsWrapper wraps createAllSRPMs to conditionally run it inside a chroot.
+// If workerTar is non-empty, packing will occur inside a chroot, otherwise it will run on the host system.
+func getURLSRPMsWrapper(specsDir, distTag, buildDir, outDir, workerTar string, workers int, nestedSourcesDir, runCheck bool, packList string, templateSrcConfig sourceRetrievalConfiguration) (result []string, err error) {
+	var chroot *safechroot.Chroot
+	originalOutDir := outDir
+	var packageURL []string
+	if workerTar != "" {
+		const leaveFilesOnDisk = false
+		chroot, buildDir, outDir, specsDir, err = createChroot(workerTar, buildDir, outDir, specsDir)
+		if err != nil {
+			return
+		}
+		defer chroot.Close(leaveFilesOnDisk)
+	}
+
+	doCreateAll := func() error {
+		packageURL, err = getURLSRPMs(specsDir, distTag, buildDir, outDir, workers, nestedSourcesDir, runCheck, packList, templateSrcConfig)
+		return err
+	}
+
+	if chroot != nil {
+		logger.Log.Info("Packing SRPMs inside a chroot environment")
+		err = chroot.Run(doCreateAll)
+	} else {
+		logger.Log.Info("Packing SRPMs in the host environment")
+		err = doCreateAll()
+	}
+
+	if err != nil {
+		return
+	}
+
+	// If this is container build then the bind mounts will not have been created.
+	// Copy the chroot output to host output folder.
+	if !buildpipeline.IsRegularBuild() {
+		srpmsInChroot := filepath.Join(chroot.RootDir(), outDir)
+		err = directory.CopyContents(srpmsInChroot, originalOutDir)
+	}
+
+	result = packageURL
+
+	return
+}
+
+// createAllSRPMs will find all SPEC files in specsDir and pack SRPMs for them if needed.
+func getURLSRPMs(specsDir, distTag, buildDir, outDir string, workers int, nestedSourcesDir, runCheck bool, specfile string, templateSrcConfig sourceRetrievalConfiguration) (result []string, err error) {
+	const (
+		emptyQueryFormat      = ``
+		querySrpm             = `%{NAME}-%{VERSION}-%{RELEASE}.src.rpm`
+		queryProvidedPackages = `rpm %{ARCH}/%{nvra}.rpm\n[provides %{PROVIDENEVRS}\n][requires %{REQUIRENEVRS}\n][arch %{ARCH}\n]`
+	)
+	logger.Log.Infof("Finding SPEC's SRPM URL")
+	sourcedir := filepath.Dir(specfile)
+	defines := rpm.DefaultDefines(runCheck)
+	// Find the SRPM associated with the SPEC.
+	return rpm.QuerySPEC(specfile, sourcedir, querySrpm, defines, rpm.QueryHeaderArgument)
+
+	// rpmspec -q $${spec_file} --srpm --define='with_check 1' --define='dist $(DIST_TAG)' --queryformat %{NAME}-%{VERSION}-%{RELEASE}.src.rpm
+}
+
+// createChroot creates a chroot to pack SRPMs inside of.
+func createChroot(workerTar, buildDir, outDir, specsDir string) (chroot *safechroot.Chroot, newBuildDir, newOutDir, newSpecsDir string, err error) {
+	const (
+		chrootName       = "srpmpacker_chroot"
+		existingDir      = false
+		leaveFilesOnDisk = false
+
+		outMountPoint    = "/output"
+		specsMountPoint  = "/specs"
+		buildDirInChroot = "/build"
+	)
+
+	extraMountPoints := []*safechroot.MountPoint{
+		safechroot.NewMountPoint(outDir, outMountPoint, "", safechroot.BindMountPointFlags, ""),
+		safechroot.NewMountPoint(specsDir, specsMountPoint, "", safechroot.BindMountPointFlags, ""),
+	}
+
+	extraDirectories := []string{
+		buildDirInChroot,
+	}
+
+	newBuildDir = buildDirInChroot
+	newOutDir = outMountPoint
+	newSpecsDir = specsMountPoint
+
+	chrootDir := filepath.Join(buildDir, chrootName)
+	chroot = safechroot.NewChroot(chrootDir, existingDir)
+
+	err = chroot.Initialize(workerTar, extraDirectories, extraMountPoints)
+	if err != nil {
+		return
+	}
+
+	defer func() {
+		if err != nil {
+			closeErr := chroot.Close(leaveFilesOnDisk)
+			if closeErr != nil {
+				logger.Log.Errorf("Failed to close chroot, err: %s", closeErr)
+			}
+		}
+	}()
+
+	// If this is container build then the bind mounts will not have been created.
+	if !buildpipeline.IsRegularBuild() {
+		// Copy in all of the SPECs so they can be packed.
+		specsInChroot := filepath.Join(chroot.RootDir(), newSpecsDir)
+		err = directory.CopyContents(specsDir, specsInChroot)
+		if err != nil {
+			return
+		}
+
+		// Copy any prepacked srpms so they will not be repacked.
+		srpmsInChroot := filepath.Join(chroot.RootDir(), newOutDir)
+		err = directory.CopyContents(outDir, srpmsInChroot)
+		if err != nil {
+			return
+		}
+	}
+
+	// Networking support is needed to download sources.
+	files := []safechroot.FileToCopy{
+		{Src: "/etc/resolv.conf", Dest: "/etc/resolv.conf"},
+	}
+
+	err = chroot.AddFiles(files...)
+	return
+}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
**All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)*
- [ ] The toolchain has been rebuilt successfully (or no changes were made to it)
- [ ] The toolchain/worker package manifests are up-to-date
- [ ] Any updated packages successfully build (or no packages were changed)
- [ ] Packages depending on static components modified in this PR (Golang, `*-static` subpackages, etc.) have had their `Release` tag incremented.
- [ ] Package tests (%check section) have been verified with RUN_CHECK=y for existing SPEC files, or added to new SPEC files
- [ ] All package sources are available
- [ ] cgmanifest files are up-to-date and sorted (`./cgmanifest.json`, `./toolkit/tools/cgmanifest.json`, `./toolkit/scripts/toolchain/cgmanifest.json`, `.github/workflows/cgmanifest.json`)
- [ ] LICENSE-MAP files are up-to-date (`./SPECS/LICENSES-AND-NOTICES/data/licenses.json`, `./SPECS/LICENSES-AND-NOTICES/LICENSES-MAP.md`, `./SPECS/LICENSES-AND-NOTICES/LICENSE-EXCEPTIONS.PHOTON`)
- [ ] All source files have up-to-date hashes in the `*.signatures.json` files
- [ ] `sudo make go-tidy-all` and `sudo make go-test-coverage` pass
- [ ] Documentation has been updated to match any changes to the build system
- [ ] Ready to merge

---

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Fix quickstart and the srpm download command

https://microsoft.visualstudio.com/OS/_sprints/taskboard/ft_iot_Mariner/OS/2209?workitem=40942962

//TO DO
// ADD TLS certs for srpm servers that need them
// Bug in SRPM_URL_LIST where setting the URL to use 1.0 still curls a .cm2 srpm (fails when same cmd runs outside of toolkit)
// Bug where the SRPM_PACK_LIST= will not clear srpm_pack_list_file ($(BUILD_SRPMS_DIR)/pack_list.txt) even if argument is empty
// A lot of code duplication w/ srpmpacker. Should make a library

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
<!-- Please list any packages which will be affected by this change, if applicable. -->
<!-- Please list any CVES fixed by this change, if applicable. -->
- Change
- Change
- Change

###### Does this affect the toolchain?  <!-- REQUIRED -->
<!-- Any packages which are included in the toolchain should be carefully considered. Make sure the toolchain builds with these changes if so. -->
<!-- Update: manifests/package/toolchain_*.txt, pkggen_core_*.txt, update_manifests.sh -->
<!-- To validate: make clean; make workplan REBUILD_TOOLCHAIN=y DISABLE_UPSTREAM_REPOS=y CONFIG_FILE="" ... -->
**YES/NO**

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
<!-- you can use "fixes #xxxx" to auto close an associated issue once the PR is merged -->
- #xxxx

###### Links to CVEs  <!-- optional -->
- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Pipeline build id: xxxx
